### PR TITLE
Error fix

### DIFF
--- a/verify/module.py
+++ b/verify/module.py
@@ -91,13 +91,6 @@ class Verify(commands.Cog):
             return
 
         code: str = self._generate_code()
-        VerifyMember.add(
-            guild_id=ctx.guild.id,
-            user_id=ctx.author.id,
-            address=address,
-            code=code,
-            status=VerifyStatus.PENDING,
-        )
 
         message: MIMEMultipart = self._get_message(
             ctx.author, ctx.channel, address, code
@@ -107,6 +100,14 @@ class Verify(commands.Cog):
 
         if not email_sent:
             return
+
+        VerifyMember.add(
+            guild_id=ctx.guild.id,
+            user_id=ctx.author.id,
+            address=address,
+            code=code,
+            status=VerifyStatus.PENDING,
+        )
 
         await guild_log.info(
             ctx.author,

--- a/voice/module.py
+++ b/voice/module.py
@@ -43,7 +43,8 @@ NOUNS = [
 
 class Voice(commands.Cog):
     """Module for dynamic VoiceChannel management.
-    Requires a VoiceChannel category, in which the category permissions are set correctly!"""
+    Requires a VoiceChannel category, in which the category permissions are set correctly!
+    """
 
     def __init__(self, bot: Bot):
         self.bot = bot
@@ -155,11 +156,13 @@ class Voice(commands.Cog):
         # Includes channels with no visitors yet
         empty_channels = list(
             filter(
-                lambda x: True
-                if isinstance(x, discord.VoiceChannel)
-                and (not x.members)
-                and (high_resolution == x.name.startswith(HIGH_RES_CHANNEL_PREFIX))
-                else False,
+                lambda x: (
+                    True
+                    if isinstance(x, discord.VoiceChannel)
+                    and (not x.members)
+                    and (high_resolution == x.name.startswith(HIGH_RES_CHANNEL_PREFIX))
+                    else False
+                ),
                 category.channels,
             )
         )


### PR DESCRIPTION
This should handle this error properly:

```
ERROR  () #jail VUT FSI: AttributeError: 'NoneType' object has no attribute 'send'
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/smtplib.py", line 969, in send_message
    ''.join([from_addr, *to_addrs]).encode('ascii')
UnicodeEncodeError: 'ascii' codec can't encode character '\u200b' in position 28: ordinal not in range(128)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/strawberry-py/modules/mgmt/verify/module.py", line 1463, in _send_email
    server.send_message(message)
  File "/usr/local/lib/python3.11/smtplib.py", line 972, in send_message
    raise SMTPNotSupportedError(
smtplib.SMTPNotSupportedError: One or more source or delivery addresses require internationalized email support, but the server does not advertise the required SMTPUTF8 capability

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/.local/lib/python3.11/site-packages/discord/ext/commands/core.py", line 235, in wrapped
    ret = await coro(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/strawberry-py/modules/mgmt/verify/module.py", line 106, in verify
    email_sent = await self._send_email(ctx, message)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/strawberry-py/modules/mgmt/verify/module.py", line 1467, in _send_email
    await bot_log.warning(
  File "/strawberry-py/pie/logger/__init__.py", line 354, in warning
    await self._log(
  File "/strawberry-py/pie/logger/__init__.py", line 276, in _log
    await self._maybe_send(entry)
  File "/strawberry-py/pie/logger/__init__.py", line 314, in _maybe_send
    await channel.send(f"")
          ^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'send'

```