### PR TITLE
[Verify] Improve verify logging security

### DIFF
--- a/po/cs.popie
+++ b/po/cs.popie
@@ -340,6 +340,12 @@ msgstr Akce nebyla dokončena.
 msgid You've been deleted from the database and your roles have been removed. You have to go through verfication in order to get back.
 msgstr Byli jste vymazáni z databáze a byly vám odebrány role. Pro návrat musíte znovu projít verifikací.
 
+msgid Anonymization is **ON**. Emails won't appear in logs.
+msgstr Anonymizace je **ZAPNUTA**. Emailové adresy se neobjeví v logu.
+
+msgid Anonymization is **OFF**. Emails will appear in logs.
+msgstr Anonymizace je **VYPNUTA**. Emailové adresy se objeví v logu.
+
 msgid Group strip
 msgstr Hromadný reset rolí
 

--- a/po/sk.popie
+++ b/po/sk.popie
@@ -340,6 +340,12 @@ msgstr Akcia nebola dokončená.
 msgid You've been deleted from the database and your roles have been removed. You have to go through verfication in order to get back.
 msgstr Boli ste vymazaný z databáze a vaše role boli odstránené. Pre návrat musíte prejsť verifikáciou.
 
+msgid Anonymization is **ON**. Emails won't appear in logs.
+msgstr Anonymizácia je **ZAPNUTÁ**. E-maily sa nezobrazia v logu.
+
+msgid Anonymization is **OFF**. Emails will appear in logs.
+msgstr msgstr Anonymizácia je **VYPNUT8**. E-maily sa zobrazia v logu.
+
 msgid Group strip
 msgstr
 


### PR DESCRIPTION
1. Removed logging of email address in case user is already in DB or email is already in DB (can be obtained using whois)
2. Added anonymization of emails in unsupported email logging.