### PR TITLE
[Verify] Fix submit using itx.author

### DIFF
--- a/verify/module.py
+++ b/verify/module.py
@@ -286,7 +286,7 @@ class Verify(commands.Cog):
             config_message = VerifyMessage.get_default(itx.guild.id)
         if not config_message:
             await utils.discord.send_dm(
-                itx.author,
+                itx.user,
                 _(itx, "You have been verified, congratulations!"),
             )
         else:


### PR DESCRIPTION
```ERROR arcastestuje (899321861035417620) #jail strojLAB Konstruování: CommandInvokeError: Command 'submit' raised an exception: AttributeError: 'Interaction' object has no attribute 'author'
Traceback (most recent call last):
  File "/root/.local/lib/python3.12/site-packages/discord/app_commands/commands.py", line 857, in _do_call
    return await self._callback(self.binding, interaction, **params)  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/strawberry-py/modules/mgmt/verify/module.py", line 289, in submit
    itx.author,
    ^^^^^^^^^^
AttributeError: 'Interaction' object has no attribute 'author'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/root/.local/lib/python3.12/site-packages/discord/app_commands/tree.py", line 1310, in _call
    await command._invoke_with_namespace(interaction, namespace)
  File "/root/.local/lib/python3.12/site-packages/discord/app_commands/commands.py", line 883, in _invoke_with_namespace
    return await self._do_call(interaction, transformed_values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/lib/python3.12/site-packages/discord/app_commands/commands.py", line 876, in _do_call
    raise CommandInvokeError(self, e) from e
discord.app_commands.errors.CommandInvokeError: Command 'submit' raised an exception: AttributeError: 'Interaction' object has no attribute 'author'```