### PR TITLE
[Verify] Fix giving to much arguments to logger

### DIFF
--- a/verify/module.py
+++ b/verify/module.py
@@ -1576,7 +1576,7 @@ class Verify(commands.Cog):
             if retry and not isinstance(exc, smtplib.SMTPNotSupportedError):
                 await bot_log.warning(
                     itx.user,
-                    itx.user,
+                    itx.channel,
                     "Could not send verification e-mail, trying again.",
                     exception=exc,
                 )
@@ -1585,8 +1585,7 @@ class Verify(commands.Cog):
                 await bot_log.error(
                     itx.user,
                     itx.channel,
-                    "Could not send verification e-mail.",
-                    "Email: {}".format(
+                    ("Could not send verification e-mail. Email: {}").format(
                         message["To"].encode("unicode-escape").decode("utf-8")
                     ),
                     exception=exc,


### PR DESCRIPTION
```
CommandInvokeError: Command 'verify' raised an exception: TypeError: AbstractLogger.error() takes 4 positional arguments but 5 positional arguments (and 1 keyword-only argument) were given
Traceback (most recent call last):
  File "/strawberry-py/modules/mgmt/verify/module.py", line 1573, in _send_email
    server.send_message(message)
  File "/usr/local/lib/python3.12/smtplib.py", line 975, in send_message
    return self.sendmail(from_addr, to_addrs, flatmsg, mail_options,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/smtplib.py", line 897, in sendmail
    raise SMTPDataError(code, resp)
smtplib.SMTPDataError: (451, b'4.4.1 error when enqueuing the message')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/strawberry-py/modules/mgmt/verify/module.py", line 1573, in _send_email
    server.send_message(message)
  File "/usr/local/lib/python3.12/smtplib.py", line 975, in send_message
    return self.sendmail(from_addr, to_addrs, flatmsg, mail_options,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/smtplib.py", line 897, in sendmail
    raise SMTPDataError(code, resp)
smtplib.SMTPDataError: (451, b'4.4.1 error when enqueuing the message')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/.local/lib/python3.12/site-packages/discord/app_commands/commands.py", line 857, in _do_call
    return await self._callback(self.binding, interaction, **params)  # type: ignore
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/strawberry-py/modules/mgmt/verify/module.py", line 122, in verify
    email_sent = await self._send_email(itx, message)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/strawberry-py/modules/mgmt/verify/module.py", li
ne 1583, in _send_email
    return await self._send_email(itx, message, False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/strawberry-py/modules/mgmt/verify/module.py", line 1585, in _send_email
    await bot_log.error(
          ^^^^^^^^^^^^^^
TypeError: AbstractLogger.error() takes 4 positional arguments but 5 positional arguments (and 1 keyword-only argument) were given

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/root/.local/lib/python3.12/site-packages/discord/app_commands/tree.py", line 1310, in _call
    await command._invoke_with_namespace(interaction, namespace)
  File "/root/.local/lib/python3.12/site-packages/discord/app_commands/commands.py", line 883, in _invoke_with_namespace
    return await self._do_call(interaction, transformed_values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/lib/python3.12/site-packages/discord/app_commands/commands.py", line 872, in _do_call
    raise CommandInvokeError(self, e) from e
discord.app_commands.errors.CommandInvokeError: Command 'verify' raised an exception: TypeError: AbstractLogger.error() takes 4 positional arguments but 5 positional arguments (and 1 keyword-only argument) were given
```