### PR TITLE
[Verify] Rework mail check and sending

### DIFF
--- a/po/cs.popie
+++ b/po/cs.popie
@@ -295,6 +295,9 @@ msgstr Nemohl ti být zaslán verifikační kód, pravděpodobně máš překlep
 msgid If I'm wrong and the e-mail is correct, contact the moderator team.
 msgstr Pokud se pletu a e-mail je správný, kontaktuj moderátory.
 
+msgid (anonymized)
+msgstr (anonymizované()
+
 msgid I've sent you the verification code to the submitted e-mail.
 msgstr Na zadaný e-mail ti byl poslán verifikační kód.
 

--- a/po/cs.popie
+++ b/po/cs.popie
@@ -296,7 +296,7 @@ msgid If I'm wrong and the e-mail is correct, contact the moderator team.
 msgstr Pokud se pletu a e-mail je správný, kontaktuj moderátory.
 
 msgid (anonymized)
-msgstr (anonymizované()
+msgstr (anonymizované)
 
 msgid I've sent you the verification code to the submitted e-mail.
 msgstr Na zadaný e-mail ti byl poslán verifikační kód.

--- a/po/cs.popie
+++ b/po/cs.popie
@@ -289,8 +289,8 @@ msgstr Role k navrácení
 msgid Channels to return
 msgstr Kanály k navrácení
 
-msgid I could not send the verification code, you've probably made a typo{address_part}. Invoke the command `/strip` before requesting a new code.
-msgstr Nemohl ti být zaslán verifikační kód, pravděpodobně máš překlep v adrese{address_part}. Použij příkaz `/strip` předtím, než zažádáš o nový kód.
+msgid I could not send the verification code, you've probably made a typo: `{address_part}`. Invoke the command `/strip` before requesting a new code.
+msgstr Nemohl ti být zaslán verifikační kód, pravděpodobně máš překlep v adrese: `{address_part}`. Použij příkaz `/strip` předtím, než zažádáš o nový kód.
 
 msgid If I'm wrong and the e-mail is correct, contact the moderator team.
 msgstr Pokud se pletu a e-mail je správný, kontaktuj moderátory.

--- a/po/cs.popie
+++ b/po/cs.popie
@@ -289,17 +289,14 @@ msgstr Role k navrácení
 msgid Channels to return
 msgstr Kanály k navrácení
 
-msgid I've sent you the verification code to the submitted e-mail.
-msgstr Na zadaný e-mail ti byl poslán verifikační kód.
-
-msgid I could not send the verification code, you've probably made a typo: `{address}`. Invoke the command `/strip` before requesting a new code.
-msgstr Nemohl ti být zaslán verifikační kód, pravděpodobně máš překlep v adrese: `{address}`. Použij příkaz `/strip` předtím, než zažádáš o nový kód.
+msgid I could not send the verification code, you've probably made a typo{address_part}. Invoke the command `/strip` before requesting a new code.
+msgstr Nemohl ti být zaslán verifikační kód, pravděpodobně máš překlep v adrese{address_part}. Použij příkaz `/strip` předtím, než zažádáš o nový kód.
 
 msgid If I'm wrong and the e-mail is correct, contact the moderator team.
 msgstr Pokud se pletu a e-mail je správný, kontaktuj moderátory.
 
-msgid {mention} I could not send the verification code, you've probably made a typo. Invoke the command `/strip` before requesting a new code.
-msgstr {mention} Nemohl ti být zaslán verifikační kód, pravděpodobně máš překlep v mailu. Použij příkaz `/strip` předtím, než zažádáš o nový kód.
+msgid I've sent you the verification code to the submitted e-mail.
+msgstr Na zadaný e-mail ti byl poslán verifikační kód.
 
 msgid You have to request the code first.
 msgstr Nejdřív musíš požádat o kód.

--- a/po/sk.popie
+++ b/po/sk.popie
@@ -289,17 +289,14 @@ msgstr Roly na vrátenie
 msgid Channels to return
 msgstr Kanály na vrátenie
 
-msgid I've sent you the verification code to the submitted e-mail.
-msgstr Na zadaný email ti bol poslaný verifikačný kód.
-
-msgid I could not send the verification code, you've probably made a typo: `{address}`. Invoke the command `/strip` before requesting a new code.
-msgstr Verifikačný kód nemohol byť poslaný, pravdepodobne je v ňom preklep: `{address}`. Použi príkaz `/strip` predtým, ako požiadaš o nový kód.
+msgid I could not send the verification code, you've probably made a typo{address_part}. Invoke the command `/strip` before requesting a new code.
+msgstr Verifikačný kód nemohol byť poslaný, pravdepodobne je v ňom preklep{address_part}. Použi príkaz `/strip` predtým, ako požiadaš o nový kód.
 
 msgid If I'm wrong and the e-mail is correct, contact the moderator team.
 msgstr Ak sa mýlim a email je správny, kontaktuj moderátorov.
 
-msgid {mention} I could not send the verification code, you've probably made a typo. Invoke the command `/strip` before requesting a new code.
-msgstr {mention} Verifikačný kód nemohol byť poslaný, pravdepodobne je v ňom preklep. Použi príkaz `/strip` predtým, ako požiadaš o nový kód.
+msgid I've sent you the verification code to the submitted e-mail.
+msgstr Na zadaný email ti bol poslaný verifikačný kód.
 
 msgid You have to request the code first.
 msgstr Musíš najskôr požiadať o kód.

--- a/po/sk.popie
+++ b/po/sk.popie
@@ -295,6 +295,9 @@ msgstr Verifikačný kód nemohol byť poslaný, pravdepodobne je v ňom preklep
 msgid If I'm wrong and the e-mail is correct, contact the moderator team.
 msgstr Ak sa mýlim a email je správny, kontaktuj moderátorov.
 
+msgid (anonymized)
+msgstr (anonymizované)
+
 msgid I've sent you the verification code to the submitted e-mail.
 msgstr Na zadaný email ti bol poslaný verifikačný kód.
 

--- a/po/sk.popie
+++ b/po/sk.popie
@@ -289,8 +289,8 @@ msgstr Roly na vrátenie
 msgid Channels to return
 msgstr Kanály na vrátenie
 
-msgid I could not send the verification code, you've probably made a typo{address_part}. Invoke the command `/strip` before requesting a new code.
-msgstr Verifikačný kód nemohol byť poslaný, pravdepodobne je v ňom preklep{address_part}. Použi príkaz `/strip` predtým, ako požiadaš o nový kód.
+msgid I could not send the verification code, you've probably made a typo: `{address_part}`. Invoke the command `/strip` before requesting a new code.
+msgstr Verifikačný kód nemohol byť poslaný, pravdepodobne je v ňom preklep: `{address_part}`. Použi príkaz `/strip` predtým, ako požiadaš o nový kód.
 
 msgid If I'm wrong and the e-mail is correct, contact the moderator team.
 msgstr Ak sa mýlim a email je správny, kontaktuj moderátorov.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+aiosmtplib
 emoji>=2.1.0
 imap_tools
 Pillow

--- a/verify/module.py
+++ b/verify/module.py
@@ -47,7 +47,7 @@ SMTP_TLS: bool = os.getenv("SMTP_TLS", "True").lower() != "false"
 
 try:
     SMTP_PORT: int = int(os.getenv("SMTP_PORT", "465"))
-except ValueError:
+except (ValueError, TypeError):
     raise exceptions.DotEnvException("SMTP_PORT must be numeber.")
 
 

--- a/verify/module.py
+++ b/verify/module.py
@@ -1556,7 +1556,6 @@ class Verify(commands.Cog):
         message["Subject"] = f"{ascii_guild_name} → {ascii_member_name}"
         message["From"] = f"{ascii_bot_name} <{SMTP_ADDRESS}>"
         message["To"] = f"{ascii_member_name} <{address}>"
-        message["Bcc"] = f"{ascii_bot_name} <{SMTP_ADDRESS}>"
 
         message[MAIL_HEADER_PREFIX + "user"] = f"{member.id}"
         message[MAIL_HEADER_PREFIX + "bot"] = f"{self.bot.user.id}"

--- a/verify/module.py
+++ b/verify/module.py
@@ -158,7 +158,9 @@ class Verify(commands.Cog):
                 and channel
             ):
                 await channel.send(
-                    f"{user.mention} {error_msg}".format(address_part="anonymized"),
+                    f"{user.mention} {error_msg}".format(
+                        address_part=_(utx, "(anonymized)")
+                    ),
                     delete_after=60,
                 )
 

--- a/verify/module.py
+++ b/verify/module.py
@@ -218,7 +218,7 @@ class Verify(commands.Cog):
         await (await itx.original_response()).edit(
             content=_(
                 itx,
-                ("I've sent you the verification code " "to the submitted e-mail."),
+                ("I've sent you the verification code to the submitted e-mail."),
             )
         )
 

--- a/verify/module.py
+++ b/verify/module.py
@@ -140,7 +140,7 @@ class Verify(commands.Cog):
                     utx,
                     (
                         "I could not send the verification code, you've probably made "
-                        "a typo{address_part}. Invoke the command `/strip` "
+                        "a typo: `{address_part}`. Invoke the command `/strip` "
                         "before requesting a new code."
                     ),
                 )
@@ -153,12 +153,12 @@ class Verify(commands.Cog):
             if (
                 not await utils.discord.send_dm(
                     user,
-                    error_msg.format(address_part=f": `{db_user.address}`"),
+                    error_msg.format(address_part=db_user.address),
                 )
                 and channel
             ):
                 await channel.send(
-                    f"{user.mention} {error_msg}",
+                    f"{user.mention} {error_msg}".format(address_part="anonymized"),
                     delete_after=60,
                 )
 

--- a/verify/module.py
+++ b/verify/module.py
@@ -1666,10 +1666,10 @@ class Verify(commands.Cog):
                 )
             ]
 
-            for m in messages:
+            for message in messages:
                 has_delivery_status: bool = False
 
-                for part in m.obj.walk():
+                for part in message.obj.walk():
                     if part.get_content_type() == "message/delivery-status":
                         has_delivery_status = True
                         break
@@ -1677,7 +1677,7 @@ class Verify(commands.Cog):
                 if not has_delivery_status:
                     continue
 
-                rfc_message = m.obj.as_string()
+                rfc_message = message.obj.as_string()
                 info: dict = {}
 
                 for line in rfc_message.split("\n"):
@@ -1687,7 +1687,7 @@ class Verify(commands.Cog):
                 if not info:
                     continue
 
-                info["subject"] = m.subject
+                info["subject"] = message.subject
                 unread_messages.append(info)
         return unread_messages
 

--- a/verify/module.py
+++ b/verify/module.py
@@ -89,7 +89,7 @@ class Verify(commands.Cog):
         name="reverify", description="Reverification commands.", parent=verification
     )
 
-    def __init__(self, bot):
+    def __init__(self, bot: Strawberry):
         self.bot: Strawberry = bot
 
     @app_commands.guild_only()
@@ -1673,5 +1673,5 @@ class Verify(commands.Cog):
         return unread_messages
 
 
-async def setup(bot) -> None:
+async def setup(bot: Strawberry) -> None:
     await bot.add_cog(Verify(bot))


### PR DESCRIPTION
Recent trouble on VUT FEKT Discord lead me to realization, that this part of verify needs rework before the same problems occurs as well.

- Email sending is now using aiosmtplib to not block whole bot when sending emails
 - I had to add SMTP_PORT and SMTP_TLS .env variables
- The email bounce is checked once every 60s in task
- The email bounce check logic is reworked, so that the bounce email is correctly linked to the user
- The email bounce check marks all emails as read

There were also two small tweaks - added typing and connected string split by `" "`