### PR TITLE
[Verify] Fix groupstriping deleted user

### DIFF
--- a/po/cs.popie
+++ b/po/cs.popie
@@ -340,11 +340,11 @@ msgstr Anonymizace je **VYPNUTA**. Emailové adresy se objeví v logu.
 msgid Group strip
 msgstr Hromadný reset rolí
 
-msgid **{member}** will lose all their roles and their verification will be revoked. They will not be notified about this. Do you want to continue?
-msgstr Uživatel **{member}** ztratí své role a jeho verifikace bude zrušena. Nebude o tomto kroku informován. Pokračovat?
+msgid **{user}** will lose all their roles and their verification will be revoked. They will not be notified about this. Do you want to continue?
+msgstr Uživatel **{user}** ztratí své role a jeho verifikace bude zrušena. Nebude o tomto kroku informován. Pokračovat?
 
-msgid Member **{member}** ({member_id}) stripped.
-msgstr Role uživatele **{member}** ({member_id}) odebrány.
+msgid User **{user}** ({user_id}) stripped.
+msgstr Role uživatele **{user}** ({user_id}) odebrány.
 
 msgid Role based strip
 msgstr Reset verifikace podle rolí

--- a/po/sk.popie
+++ b/po/sk.popie
@@ -340,11 +340,11 @@ msgstr msgstr Anonymizácia je **VYPNUT8**. E-maily sa zobrazia v logu.
 msgid Group strip
 msgstr
 
-msgid **{member}** will lose all their roles and their verification will be revoked. They will not be notified about this. Do you want to continue?
-msgstr **{member}** stratí všetky svoje role a jeho overenie bude zrušené. Nebude o tom informován. Chceš pokračovať?
+msgid **{user}** will lose all their roles and their verification will be revoked. They will not be notified about this. Do you want to continue?
+msgstr **{user}** stratí všetky svoje role a jeho overenie bude zrušené. Nebude o tom informován. Chceš pokračovať?
 
-msgid Member **{member}** ({member_id}) stripped.
-msgstr Overenie uživateľa **{member} ({member_id}) bolo zrušené.
+msgid User **{user}** ({user_id}) stripped.
+msgstr Overenie uživateľa **{user} ({user_id}) bolo zrušené.
 
 msgid Role based strip
 msgstr


### PR DESCRIPTION
When the user does not exist (banned / deleted), the groupstrip command has trouble transforming it to Member object and throws an error bellow. Changing the parameter to discord.User fixes this issue, however, we must get the Guild member info later on to remove the roles (if any).

```
TransformerError: Failed to convert deleted_user_2dbb126b5116 to Member
Traceback (most recent call last):
  File "/root/.local/lib/python3.12/site-packages/discord/app_commands/tree.py", line 1310, in _call
    await command._invoke_with_namespace(interaction, namespace)
  File "/root/.local/lib/python3.12/site-packages/discord/app_commands/commands.py", line 882, in _invoke_with_namespace
    transformed_values = await self._transform_arguments(interaction, namespace)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/lib/python3.12/site-packages/discord/app_commands/commands.py", line 848, in _transform_arguments
    transformed_values[param.name] = await param.transform(interaction, value)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/lib/python3.12/site-packages/discord/app_commands/transformers.py", line 180, in transform
    return await maybe_coroutine(self._annotation.transform, interaction, value)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.local/lib/python3.12/site-packages/discord/utils.py", line 694, in maybe_coroutine
    return await value
           ^^^^^^^^^^^
  File "/root/.local/lib/python3.12/site-packages/discord/app_commands/transformers.py", line 621, in transform
    raise TransformerError(value, self.type, self)
discord.app_commands.errors.TransformerError: Failed to convert deleted_user_2dbb126b5116 to Member
```