### PR TITLE
[Verify] Improve mapping speed and reliability

### DIFF
--- a/po/cs.popie
+++ b/po/cs.popie
@@ -412,12 +412,6 @@ msgstr Zpracovávám. Uvař si kafe, bude to chvíli trvat.
 msgid Wiped {wiped} mappings.
 msgstr Smazáno {wiped} mapování.
 
-msgid Row {row} has invalid number of columns!
-msgstr Řádek {row} má špatný počet sloupců!
-
-msgid Row {row} has invalid rule name: {name}!
-msgstr Řádek {row} má špatný název pravidla: {name}!
-
 msgid Imported {count} mappings.
 msgstr Importováno {count} mapování.
 
@@ -486,6 +480,9 @@ msgstr Ukázka reverify zrušena.
 
 msgid Do you really want to execute reverify? The operation is **irreversible**.This operation might take a while and the bot might hit rate limit!
 msgstr Opravdu chcete spustit reverifikaci? Opreace je **nevratná**. Tato operace může chvíli trvat a bot může narazit na rate limit!
+
+msgid Invalid rule name found: {name}!
+msgstr Špatný název pravidla: {name}!
 
 msgid Reverification starting...
 msgstr Reverifikace začíná...

--- a/po/sk.popie
+++ b/po/sk.popie
@@ -412,12 +412,6 @@ msgstr
 msgid Wiped {wiped} mappings.
 msgstr
 
-msgid Row {row} has invalid number of columns!
-msgstr
-
-msgid Row {row} has invalid rule name: {name}!
-msgstr
-
 msgid Imported {count} mappings.
 msgstr
 
@@ -485,6 +479,9 @@ msgid Reverify preview aborted.
 msgstr
 
 msgid Do you really want to execute reverify? The operation is **irreversible**.This operation might take a while and the bot might hit rate limit!
+msgstr
+
+msgid Invalid rule name found: {name}!
 msgstr
 
 msgid Reverification starting...

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ imap_tools
 Pillow
 unidecode
 python-dateutil
+pandas


### PR DESCRIPTION
I've noticed two possible spots for improvement.

First was that with each mapping there was a DB query for the VerifyRule, which slows down the import process when importing large amount of data. To solve this, I've introduced a dictionary that maps VerifyRule name to VerifyRule object.

The second spot was that when importing the data, there's always an upsert process that checks the existance of data in DB and either updates existing or inserts new record. However, for bulk updates with wipe, this is not necessary. Therefor for wipe process I've replaced the code with a bulk insert, which is as much more faster.